### PR TITLE
use Commit SHA in build binary naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
-BINARY_NAME=grpclab
+COMMITSHA=$(shell git rev-parse --short HEAD)
+BINARY_NAME=grpclab_$(COMMITSHA)
 
 all: test build
 


### PR DESCRIPTION
Add `git rev-parse --short HEAD` to acquire the short SHA value of the current branch and use it in built binary name. (eg: grpclab_COMMITSHA).